### PR TITLE
:books: docs: Updated Link to Contributors Site

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Once you have completed these steps, you are ready to start contributing by clic
 If you liked working on this project, please share this project as much as you can and star this project to help as many people in opensource as you can.
 
 ### 5. Get you name engraved as a contributor here
-<a href="hacktoberfest-2022-react.vercel.app">hacktoberfest-2022-react.vercel.app</a>
+<a href="https://hacktoberfest-2022-react.vercel.app">hacktoberfest-2022-react.vercel.app</a>
 
 ## Note:
 


### PR DESCRIPTION
On README.md, there's a broken link. The link to Contributors Site.

This site: https://hacktoberfest-2022-react.vercel.app/

It was broken because needed the indication to send the user to external link, the HTTPS.